### PR TITLE
[FIXED JENKINS-21163] Update pom dependencies to match git plugin - JGit and Jenkins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>1.1.29</version>
+      <version>2.0.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Updated JGit to 3.2.0

Updated Jenkins to 1.480

Updated git dependency to 2.0.1

Updated two other dependent libraries to their most recent versions.
