### PR TITLE
Use JGit http from git client plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.480</version>
+    <version>1.509</version>
   </parent>
 
   <artifactId>git-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,6 @@
   <version>1.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
   
-  <properties>
-    <jgit.version>3.4.1.201406201815-r</jgit.version>
-  </properties>
-
   <name>Git server plugin</name>
   <description>
     This library plugin provides embedded Git server capability inside Jenkins
@@ -43,15 +39,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jgit</groupId>
-      <artifactId>org.eclipse.jgit.http.server</artifactId>
-      <version>${jgit.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.jgit</groupId>
-      <artifactId>org.eclipse.jgit</artifactId>
-      <version>${jgit.version}</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git-client</artifactId>
+      <version>1.11.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>1.11.0-SNAPSHOT</version>
+      <version>1.11.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
As noted in [JENKINS-21756](https://issues.jenkins-ci.org/browse/JENKINS-21756), it is more complicated than necessary to have a direct dependency on JGit http server in git-server.  Instead, as Kohsuke suggested, it is simpler if git-client-plugin includes the JGit http component so that git-server (and others if needed) can depend on git-client-plugin without requiring that they include (and track) their own version of JGit.

The JGit http is included in [git-client-plugin 1.11.0](https://wiki.jenkins-ci.org/display/JENKINS/Git+Client+Plugin#GitClientPlugin-ChangeLog) and later.
