### PR TITLE
[JENKINS-35510] Update to parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,16 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+        <!-- This can be removed after upgrade from 1.480 -->
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <configuration>
+                    <disabledTestInjection>true</disabledTestInjection>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.9</version>
+    <version>2.11</version>
   </parent>
 
   <artifactId>git-server</artifactId>
@@ -18,7 +18,7 @@
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Git+Server+Plugin</url>
 
   <properties>
-    <jenkins.version>1.480</jenkins.version>
+    <jenkins.version>1.580.1</jenkins.version>
     <java.level>6</java.level>
   </properties>
 
@@ -50,16 +50,6 @@
       <version>1.11.0</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.sonatype.sisu</groupId>
-          <artifactId>sisu-guice</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -95,16 +95,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        <plugins>
-        <!-- This can be removed after upgrade from 1.480 -->
-            <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <configuration>
-                    <disabledTestInjection>true</disabledTestInjection>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.480</version>
+    <version>2.9</version>
   </parent>
 
   <artifactId>git-server</artifactId>
@@ -18,8 +18,8 @@
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Git+Server+Plugin</url>
 
   <properties>
-    <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
-    <findbugs.failOnError>true</findbugs.failOnError>
+    <jenkins.version>1.480</jenkins.version>
+    <java.level>6</java.level>
   </properties>
 
   <scm>
@@ -41,7 +41,7 @@
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>sshd</artifactId>
       <version>1.6</version>
-      <scope>provided</scope><!-- this is in the core -->
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -51,12 +51,15 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <version>3.0.0</version>
-      <scope>provided</scope>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.sonatype.sisu</groupId>
+          <artifactId>sisu-guice</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
-
   </dependencies>
 
   <repositories>
@@ -72,57 +75,16 @@
     </pluginRepository>
   </pluginRepositories>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.1</version>
-            </plugin>
-            <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <version>1.96</version>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>         
+    <build>      
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>com.cloudbees</groupId>
-                    <artifactId>maven-license-plugin</artifactId>
-                    <version>1.7</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.kohsuke</groupId>
-                    <artifactId>access-modifier-checker</artifactId>
-                    <version>1.3</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.jvnet.localizer</groupId>
-                    <artifactId>maven-localizer-plugin</artifactId>
-                    <version>1.14</version>
-                </plugin>
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself. -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
                     <configuration>
                         <lifecycleMappingMetadata>
                             <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-enforcer-plugin</artifactId>
-                                        <versionRange>[1.0,)</versionRange>
-                                        <goals>
-                                            <goal>display-info</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
                                 <pluginExecution>
                                     <pluginExecutionFilter>
                                         <groupId>org.codehaus.gmaven</groupId>
@@ -140,24 +102,6 @@
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>
-                </plugin>
-                <plugin>
-                  <groupId>org.codehaus.mojo</groupId>
-                  <artifactId>findbugs-maven-plugin</artifactId>
-                  <version>${findbugs-maven-plugin.version}</version>
-                  <configuration>
-                    <failOnError>${findbugs.failOnError}</failOnError>
-                    <xmlOutput>true</xmlOutput>
-                  </configuration>
-                  <executions>
-                    <execution>
-                      <id>run-findbugs</id>
-                      <phase>verify</phase> 
-                      <goals>
-                        <goal>check</goal> 
-                      </goals>
-                    </execution>
-                  </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -55,46 +55,14 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
-    <build>      
-        <pluginManagement>
-            <plugins>
-                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself. -->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.codehaus.gmaven</groupId>
-                                        <artifactId>gmaven-plugin</artifactId>
-                                        <versionRange>[1.3,)</versionRange>
-                                        <goals>
-                                            <goal>generateTestStubs</goal>
-                                            <goal>testCompile</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 
 </project>

--- a/src/main/java/org/jenkinsci/plugins/gitserver/ChannelTransport.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/ChannelTransport.java
@@ -4,6 +4,7 @@ import hudson.FilePath;
 import hudson.FilePath.FileCallable;
 import hudson.remoting.Pipe;
 import hudson.remoting.VirtualChannel;
+import jenkins.MasterToSlaveFileCallable;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.errors.NotSupportedException;
 import org.eclipse.jgit.errors.TransportException;
@@ -88,7 +89,7 @@ public class ChannelTransport extends Transport implements PackTransport {
         // no-op
     }
 
-    private static class GitFetchTask implements FileCallable<Void> {
+    private static class GitFetchTask extends MasterToSlaveFileCallable<Void> {
         private final Pipe l2r;
         private final Pipe r2l;
 
@@ -111,7 +112,7 @@ public class ChannelTransport extends Transport implements PackTransport {
         }
     }
 
-    private static class GitPushTask implements FileCallable<Void> {
+    private static class GitPushTask extends MasterToSlaveFileCallable<Void> {
         private final Pipe l2r;
         private final Pipe r2l;
 

--- a/src/main/java/org/jenkinsci/plugins/gitserver/HttpGitRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/HttpGitRepository.java
@@ -106,8 +106,12 @@ public abstract class HttpGitRepository {
                     return "";
                 }
 
-                public ServletContext getServletContext() {
-                    return Jenkins.getInstance().servletContext;
+                public ServletContext getServletContext() throws IllegalStateException {
+                    Jenkins j = Jenkins.getInstance();
+                    if (j == null) {
+                        throw new IllegalStateException();
+                    }
+                    return j.servletContext;
                 }
 
                 public String getInitParameter(String name) {

--- a/src/main/java/org/jenkinsci/plugins/gitserver/RepositoryResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/RepositoryResolver.java
@@ -63,7 +63,11 @@ public abstract class RepositoryResolver implements ExtensionPoint {
      */
     public abstract UploadPack createUploadPack(String fullRepositoryName) throws IOException, InterruptedException;
 
-    public static ExtensionList<RepositoryResolver> all() {
-        return Jenkins.getInstance().getExtensionList(RepositoryResolver.class);
+    public static ExtensionList<RepositoryResolver> all() throws IllegalStateException {
+        Jenkins j = Jenkins.getInstance();
+        if (j == null) {
+            throw new IllegalStateException();
+        }
+        return j.getExtensionList(RepositoryResolver.class);
     }
 }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   Allows Jenkins to act as a Git server.
 </div>


### PR DESCRIPTION
[JENKINS-35510](https://issues.jenkins-ci.org/browse/JENKINS-35510)

Updated to parent pom.  Removed a few of the dependencies inherited from the parent.  I kept jenkins.version at 1.480, and had to include an exclusion for sisu-guice.  The lifecycle-mapping configuration stands as it's less stringent than the parent-pom.   jenkins.version and
github-client  upgrades may be beyond the scope of this work item.  Additional details are on the JIRA ticket.

@reviewbybees 