### PR TITLE
Update plugin POM

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,1 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <revision>1.8</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>2.1</version>
+      <version>2.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>sshd</artifactId>
-      <version>1.11</version>
+      <version>2.4</version>
       <scope>provided</scope>
     </dependency>
 
@@ -78,17 +78,15 @@
               <excludes combine.children="append">
                 <!--
                     We want to be able to build and test this plugin against two
-                    Jenkins baselines: 2.60.3 (for Java 8) and 2.164.1 (for
-                    Java 11). The former provides instance-identity 2.1 and sshd
-                    1.11, while the latter provides instance-identity 2.2 and
-                    sshd 2.6. Selecting the correct set of dependencies for one
-                    Jenkins baseline breaks RequireUpperBoundDeps for the other
-                    Jenkins baseline. In the long term, JENKINS-55582 might
-                    alleviate this issue. In the short term, we work around it
-                    by excluding these libraries from the RequireUpperBoundDeps
-                    check.
+                    Jenkins baselines: 2.138.4 (for Java 8) and 2.164.1 (for
+                    Java 11). The former provides sshd 2.4, while the latter
+                    provides sshd 2.6. Selecting the correct set of dependencies
+                    for one Jenkins baseline breaks RequireUpperBoundDeps for
+                    the other Jenkins baseline. In the long term, JENKINS-55582
+                    might alleviate this issue. In the short term, we work
+                    around it by excluding this module from the
+                    RequireUpperBoundDeps check.
                 -->
-                <exclude>org.jenkins-ci.modules:instance-identity</exclude>
                 <exclude>org.jenkins-ci.modules:sshd</exclude>
               </excludes>
             </requireUpperBoundDeps>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.11</version>
+    <version>3.48</version>
   </parent>
 
   <artifactId>git-server</artifactId>
@@ -15,23 +15,24 @@
   <description>
     This library plugin provides embedded Git server capability inside Jenkins
   </description>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Git+Server+Plugin</url>
+  <url>https://wiki.jenkins.io/display/JENKINS/Git+Server+Plugin</url>
 
   <properties>
-    <jenkins.version>1.580.1</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>2.60.3</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>HEAD</tag>
   </scm>
 
   <licenses>
     <license>
       <name>The MIT license</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <url>https://www.opensource.org/licenses/mit-license.php</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -39,15 +40,27 @@
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>instance-identity</artifactId>
+      <version>2.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>ssh-cli-auth</artifactId>
+      <version>1.4</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>sshd</artifactId>
-      <version>1.6</version>
+      <version>1.11</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>1.11.0</version>
+      <version>2.7.6</version>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,37 @@
 
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <rules>
+            <requireUpperBoundDeps>
+              <excludes combine.children="append">
+                <!--
+                    We want to be able to build and test this plugin against two
+                    Jenkins baselines: 2.60.3 (for Java 8) and 2.164.1 (for
+                    Java 11). The former provides instance-identity 2.1 and sshd
+                    1.11, while the latter provides instance-identity 2.2 and
+                    sshd 2.6. Selecting the correct set of dependencies for one
+                    Jenkins baseline breaks RequireUpperBoundDeps for the other
+                    Jenkins baseline. In the long term, JENKINS-55582 might
+                    alleviate this issue. In the short term, we work around it
+                    by excluding these libraries from the RequireUpperBoundDeps
+                    check.
+                -->
+                <exclude>org.jenkins-ci.modules:instance-identity</exclude>
+                <exclude>org.jenkins-ci.modules:sshd</exclude>
+              </excludes>
+            </requireUpperBoundDeps>
+          </rules>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>git-server</artifactId>
-  <version>1.8-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
   
   <name>Jenkins GIT server Plugin</name>
@@ -18,6 +18,8 @@
   <url>https://wiki.jenkins.io/display/JENKINS/Git+Server+Plugin</url>
 
   <properties>
+    <revision>1.8</revision>
+    <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
@@ -26,7 +28,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <licenses>

--- a/src/main/java/org/jenkinsci/plugins/gitserver/CSRFExclusionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/CSRFExclusionImpl.java
@@ -4,6 +4,7 @@ import hudson.Extension;
 import hudson.security.csrf.CrumbExclusion;
 
 import javax.servlet.FilterChain;
+import javax.servlet.ReadListener;
 import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
@@ -83,8 +84,23 @@ public class CSRFExclusionImpl extends CrumbExclusion {
             public ServletInputStream getInputStream() throws IOException {
                 return new ServletInputStream() {
                     @Override
+                    public boolean isFinished() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isReady() {
+                        return true;
+                    }
+
+                    @Override
                     public int read() throws IOException {
                         return -1;
+                    }
+
+                    @Override
+                    public void setReadListener(ReadListener readListener) {
+                        // Do nothing.
                     }
                 };
             }


### PR DESCRIPTION
Supercedes #7 and #9.

- Update Jenkins Core requirement to 2.60.3 and Java 8
- Update Plugin POM to latest version
- Fix Servlet API 3.x binary compatibility issue
- Build on both Java 8 and 11
- Incrementalify the plugin