### PR TITLE
Use `instance-identity` as a plugin rather than a module

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.3</version>
+    <version>1.4</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
-def configurations = [
-    [ platform: "linux", jdk: "8" ],
-    [ platform: "linux", jdk: "11" ]
-]
-buildPlugin(configurations: configurations)
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'windows', jdk: '11' ],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.40</version>
+    <version>4.44</version>
+    <relativePath />
   </parent>
 
   <artifactId>git-server</artifactId>
@@ -20,7 +21,7 @@
   <properties>
     <revision>1.12</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.289.3</jenkins.version>
+    <jenkins.version>2.357</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -43,8 +44,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.289.x</artifactId>
-        <version>987.v4ade2e49fe70</version>
+        <artifactId>bom-2.346.x</artifactId>
+        <version>1554.v77b_8d3b_46a_37</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -55,8 +56,7 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>2.2</version>
-      <scope>provided</scope>
+      <version>116.vf8f487400980</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
Not needed for BOM in the short term, but a generally positive maintenance step IMHO. CC @jglick 