### PR TITLE
[JENKINS-72606] Make Git repos work via HTTP

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitserver/CSRFExclusionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/CSRFExclusionImpl.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.gitserver;
 import hudson.Extension;
 import hudson.security.csrf.CrumbExclusion;
 
+import java.util.List;
 import javax.servlet.FilterChain;
 import javax.servlet.ReadListener;
 import javax.servlet.ServletException;
@@ -42,7 +43,7 @@ import java.util.Vector;
 public class CSRFExclusionImpl extends CrumbExclusion {
 
     public boolean process(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
-        if (!"application/x-git-receive-pack-request".equals(request.getHeader("Content-Type")))
+        if (!List.of("application/x-git-receive-pack-request", "application/x-git-upload-pack-request").contains(request.getHeader("Content-Type")))
             return false;
 
 //        String path = request.getPathInfo();


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-72606

### Testing done

Installed https://plugins.jenkins.io/git-userContent/ and ran

`GIT_TRACE=1 GIT_TRACE_PACKET=1 GIT_CURL_VERBOSE=1 git clone http://localhost/8080/userContent.git`

Without this fix, it fails with

```
09:12:45.193646 http.c:646              => Send header, 0000000264 bytes (0x00000108)
09:12:45.193649 http.c:658              => Send header: POST /userContent.git/git-upload-pack HTTP/1.1
09:12:45.193650 http.c:658              => Send header: Host: localhost:8080
09:12:45.193652 http.c:658              => Send header: User-Agent: git/2.39.3 (Apple Git-145)
09:12:45.193653 http.c:658              => Send header: Accept-Encoding: deflate, gzip
09:12:45.193654 http.c:658              => Send header: Content-Type: application/x-git-upload-pack-request
09:12:45.193656 http.c:658              => Send header: Accept: application/x-git-upload-pack-result
09:12:45.193657 http.c:658              => Send header: Content-Length: 157
09:12:45.193658 http.c:658              => Send header:
09:12:45.194968 http.c:646              <= Recv header, 0000000024 bytes (0x00000018)
09:12:45.194989 http.c:658              <= Recv header: HTTP/1.1 403 Forbidden
09:12:45.194993 http.c:646              <= Recv header, 0000000037 bytes (0x00000025)
09:12:45.194999 http.c:658              <= Recv header: Date: Thu, 25 Jan 2024 08:12:45 GMT
09:12:45.195002 http.c:646              <= Recv header, 0000000033 bytes (0x00000021)
09:12:45.195004 http.c:658              <= Recv header: X-Content-Type-Options: nosniff
09:12:45.195006 http.c:646              <= Recv header, 0000000050 bytes (0x00000032)
09:12:45.195009 http.c:658              <= Recv header: Cache-Control: must-revalidate,no-cache,no-store
09:12:45.195012 http.c:646              <= Recv header, 0000000019 bytes (0x00000013)
09:12:45.195013 http.c:658              <= Recv header: Content-Length: 0
09:12:45.195015 http.c:646              <= Recv header, 0000000024 bytes (0x00000018)
09:12:45.195017 http.c:658              <= Recv header: Server: Jetty(10.0.18)
09:12:45.195019 http.c:646              <= Recv header, 0000000002 bytes (0x00000002)
09:12:45.195020 http.c:658              <= Recv header:
09:12:45.195026 http.c:699              == Info: Connection #0 to host localhost left intact
error: RPC failed; HTTP 403 curl 22 The requested URL returned error: 403
fatal: the remote end hung up unexpectedly
```

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
