### PR TITLE
Modernize to Jenkins 2.479 and Jakarta EE 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ mvn.out*
 .settings/
 .repository/
 .settings.xml
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -5,7 +6,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>4.86</version>
-    <relativePath/>
+    <relativePath />
   </parent>
 
   <artifactId>git-server</artifactId>
@@ -15,21 +16,6 @@
   <name>Jenkins Git server Plugin</name>
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
-  <properties>
-    <changelist>999999-SNAPSHOT</changelist>
-    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.440</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-  </properties>
-
-  <scm>
-    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
-    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <url>https://github.com/${gitHubRepo}</url>
-    <tag>${scmTag}</tag>
-  </scm>
-
   <licenses>
     <license>
       <name>The MIT license</name>
@@ -38,14 +24,29 @@
     </license>
   </licenses>
 
+  <scm>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
+  </scm>
+
+  <properties>
+    <changelist>999999-SNAPSHOT</changelist>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.440</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
         <version>3234.v5ca_5154341ef</version>
-        <scope>import</scope>
         <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.6</version>
     <relativePath />
   </parent>
 
@@ -34,8 +34,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.440</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -44,7 +44,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3234.v5ca_5154341ef</version>
+        <version>4023.va_eeb_b_4e45f07</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit.ssh.apache</artifactId>
-      <version>6.9.0.202403050737-r</version>
+      <version>7.0.0.202409031743-r</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/gitserver/ChannelTransport.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/ChannelTransport.java
@@ -53,6 +53,7 @@ public class ChannelTransport extends Transport implements PackTransport {
         } catch (IOException e) {
             throw new TransportException("Failed to open a fetch connection", e);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new TransportException("Failed to open a fetch connection", e);
         }
 
@@ -74,6 +75,7 @@ public class ChannelTransport extends Transport implements PackTransport {
         } catch (IOException e) {
             throw new TransportException("Failed to open a fetch connection", e);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new TransportException("Failed to open a fetch connection", e);
         }
 
@@ -100,15 +102,13 @@ public class ChannelTransport extends Transport implements PackTransport {
         }
 
         public Void invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
-            Repository repo = new FileRepositoryBuilder().setWorkTree(f).build();
-            try {
+            try (Repository repo = new FileRepositoryBuilder().setWorkTree(f).build()) {
                 final UploadPack rp = new UploadPack(repo);
                 rp.upload(new BufferedInputStream(l2r.getIn()), new BufferedOutputStream(r2l.getOut()), null);
                 return null;
             } finally {
                 IOUtils.closeQuietly(l2r.getIn());
                 IOUtils.closeQuietly(r2l.getOut());
-                repo.close();
             }
         }
     }
@@ -123,15 +123,13 @@ public class ChannelTransport extends Transport implements PackTransport {
         }
 
         public Void invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
-            Repository repo = new FileRepositoryBuilder().setWorkTree(f).build();
-            try {
+            try (Repository repo = new FileRepositoryBuilder().setWorkTree(f).build()) {
                 final ReceivePack rp = new ReceivePack(repo);
                 rp.receive(new BufferedInputStream(l2r.getIn()), new BufferedOutputStream(r2l.getOut()), null);
                 return null;
             } finally {
                 IOUtils.closeQuietly(l2r.getIn());
                 IOUtils.closeQuietly(r2l.getOut());
-                repo.close();
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/gitserver/FileBackedHttpGitRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/FileBackedHttpGitRepository.java
@@ -1,5 +1,13 @@
 package org.jenkinsci.plugins.gitserver;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.servlet.http.HttpServletRequest;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.eclipse.jgit.api.AddCommand;
@@ -17,15 +25,6 @@ import org.eclipse.jgit.transport.ReceivePack;
 import org.eclipse.jgit.transport.UploadPack;
 import org.eclipse.jgit.transport.resolver.ServiceNotAuthorizedException;
 import org.eclipse.jgit.transport.resolver.ServiceNotEnabledException;
-
-import javax.servlet.http.HttpServletRequest;
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.Collection;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Convenient subtype of {@link HttpGitRepository} where the repository
@@ -76,11 +75,11 @@ public abstract class FileBackedHttpGitRepository extends HttpGitRepository {
             cmd.call();
 
             CommitCommand co = git.commit();
-            co.setAuthor("Jenkins","noreply@jenkins-ci.org");
+            co.setAuthor("Jenkins", "noreply@jenkins-ci.org");
             co.setMessage("Initial import of the existing contents");
             co.call();
         } catch (GitAPIException e) {
-            LOGGER.log(Level.WARNING, "Initial import of "+workspace+" into Git repository failed",e);
+            LOGGER.log(Level.WARNING, "Initial import of " + workspace + " into Git repository failed", e);
         }
     }
 
@@ -94,7 +93,8 @@ public abstract class FileBackedHttpGitRepository extends HttpGitRepository {
      * where /foo/bar is rwx------ and /foo/bar/zot is rwxrwxrwx.)
      */
     @Override
-    public UploadPack createUploadPack(HttpServletRequest context, Repository db) throws ServiceNotEnabledException, ServiceNotAuthorizedException {
+    public UploadPack createUploadPack(HttpServletRequest context, Repository db)
+            throws ServiceNotEnabledException, ServiceNotAuthorizedException {
         return new UploadPack(db);
     }
 
@@ -102,12 +102,13 @@ public abstract class FileBackedHttpGitRepository extends HttpGitRepository {
      * Requires the admin access to be able to push
      */
     @Override
-    public ReceivePack createReceivePack(HttpServletRequest context, Repository db) throws ServiceNotEnabledException, ServiceNotAuthorizedException {
+    public ReceivePack createReceivePack(HttpServletRequest context, Repository db)
+            throws ServiceNotEnabledException, ServiceNotAuthorizedException {
         Authentication a = Jenkins.getAuthentication();
 
         ReceivePack rp = createReceivePack(db);
 
-        rp.setRefLogIdent(new PersonIdent(a.getName(), a.getName()+"@"+context.getRemoteAddr()));
+        rp.setRefLogIdent(new PersonIdent(a.getName(), a.getName() + "@" + context.getRemoteAddr()));
 
         return rp;
     }
@@ -125,7 +126,7 @@ public abstract class FileBackedHttpGitRepository extends HttpGitRepository {
                 } catch (Exception e) {
                     StringWriter sw = new StringWriter();
                     e.printStackTrace(new PrintWriter(sw));
-                    rp.sendMessage("Failed to update workspace: "+sw);
+                    rp.sendMessage("Failed to update workspace: " + sw);
                 }
             }
         });

--- a/src/main/java/org/jenkinsci/plugins/gitserver/HttpGitRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/HttpGitRepository.java
@@ -1,6 +1,15 @@
 package org.jenkinsci.plugins.gitserver;
 
 import hudson.model.Action;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Vector;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
 import jenkins.model.Jenkins;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
 import org.eclipse.jgit.http.server.GitServlet;
@@ -15,16 +24,6 @@ import org.eclipse.jgit.transport.resolver.UploadPackFactory;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
-import java.util.Enumeration;
-import java.util.Vector;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 /**
  * UI-bound object that exposes a Git repository via HTTP.
  *
@@ -38,8 +37,7 @@ public abstract class HttpGitRepository {
     private GitServlet g;
     private Exception causeOfDeath;
 
-    public HttpGitRepository() {
-    }
+    public HttpGitRepository() {}
 
     /**
      * Opens the repository this UI-bound object holds on to.
@@ -60,7 +58,8 @@ public abstract class HttpGitRepository {
      *
      * @see ReceivePackFactory#create(Object, Repository)
      */
-    public abstract ReceivePack createReceivePack(HttpServletRequest context, Repository db) throws ServiceNotEnabledException, ServiceNotAuthorizedException;
+    public abstract ReceivePack createReceivePack(HttpServletRequest context, Repository db)
+            throws ServiceNotEnabledException, ServiceNotAuthorizedException;
 
     /**
      * Returns the {@link UploadPack} that handles "git fetch" from client.
@@ -73,9 +72,10 @@ public abstract class HttpGitRepository {
      *
      * @see UploadPackFactory#create(Object, Repository)
      */
-    public abstract UploadPack createUploadPack(HttpServletRequest context, Repository db) throws ServiceNotEnabledException, ServiceNotAuthorizedException;
+    public abstract UploadPack createUploadPack(HttpServletRequest context, Repository db)
+            throws ServiceNotEnabledException, ServiceNotAuthorizedException;
 
-     /**
+    /**
      * to make sure the user has the permission to pull.
      */
     public void checkPullPermission() {
@@ -89,21 +89,23 @@ public abstract class HttpGitRepository {
                 try {
                     return openRepository();
                 } catch (IOException e) {
-                    throw new RepositoryNotFoundException(req.getRequestURI(),e);
+                    throw new RepositoryNotFoundException(req.getRequestURI(), e);
                 }
             }
         });
 
         // this creates (and thus configures) the receiver program
         g.setReceivePackFactory(new ReceivePackFactory<HttpServletRequest>() {
-            public ReceivePack create(HttpServletRequest req, Repository db) throws ServiceNotEnabledException, ServiceNotAuthorizedException {
-                return createReceivePack(req,db);
+            public ReceivePack create(HttpServletRequest req, Repository db)
+                    throws ServiceNotEnabledException, ServiceNotAuthorizedException {
+                return createReceivePack(req, db);
             }
         });
 
         g.setUploadPackFactory(new UploadPackFactory<HttpServletRequest>() {
-            public UploadPack create(HttpServletRequest req, Repository db) throws ServiceNotEnabledException, ServiceNotAuthorizedException {
-                return createUploadPack(req,db);
+            public UploadPack create(HttpServletRequest req, Repository db)
+                    throws ServiceNotEnabledException, ServiceNotAuthorizedException {
+                return createUploadPack(req, db);
             }
         });
 
@@ -130,7 +132,7 @@ public abstract class HttpGitRepository {
                 }
             });
         } catch (ServletException e) {
-            LOGGER.log(Level.WARNING,"Failed to initialize GitServlet for " + this,e);
+            LOGGER.log(Level.WARNING, "Failed to initialize GitServlet for " + this, e);
             causeOfDeath = e;
         }
         return g;
@@ -140,27 +142,24 @@ public abstract class HttpGitRepository {
      * Handles git smart HTTP protocol.
      */
     public void doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        if (g==null)
-            g=init();
+        if (g == null) g = init();
 
-        if (causeOfDeath!=null)
-            throw new ServletException(causeOfDeath);
+        if (causeOfDeath != null) throw new ServletException(causeOfDeath);
 
         // This is one place where we allow POST without CSRF headers
         HttpServletRequest realRequest = CSRFExclusionImpl.unwrapRequest(req);
-        if (realRequest==null)
-            realRequest = req;
+        if (realRequest == null) realRequest = req;
 
         /*
-            GitServlet uses getPathInfo() to determine the current request, whereas in Stapler's sense it should be using
-            getRestOfPath().
+           GitServlet uses getPathInfo() to determine the current request, whereas in Stapler's sense it should be using
+           getRestOfPath().
 
-            However, this nicely cancels out with the the GitServlet behavior of wanting one token that specifies
-            the repository to work with.
+           However, this nicely cancels out with the the GitServlet behavior of wanting one token that specifies
+           the repository to work with.
 
-            So in this case one bug cancels out another and it works out well.
-         */
-        g.service(realRequest,rsp);
+           So in this case one bug cancels out another and it works out well.
+        */
+        g.service(realRequest, rsp);
     }
 
     private static final Logger LOGGER = Logger.getLogger(HttpGitRepository.class.getName());

--- a/src/main/java/org/jenkinsci/plugins/gitserver/HttpGitRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/HttpGitRepository.java
@@ -1,15 +1,17 @@
 package org.jenkinsci.plugins.gitserver;
 
+import hudson.Util;
 import hudson.model.Action;
+import io.jenkins.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Enumeration;
-import java.util.Vector;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
 import jenkins.model.Jenkins;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
 import org.eclipse.jgit.http.server.GitServlet;
@@ -21,8 +23,8 @@ import org.eclipse.jgit.transport.resolver.ReceivePackFactory;
 import org.eclipse.jgit.transport.resolver.ServiceNotAuthorizedException;
 import org.eclipse.jgit.transport.resolver.ServiceNotEnabledException;
 import org.eclipse.jgit.transport.resolver.UploadPackFactory;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 /**
  * UI-bound object that exposes a Git repository via HTTP.
@@ -37,7 +39,7 @@ public abstract class HttpGitRepository {
     private GitServlet g;
     private Exception causeOfDeath;
 
-    public HttpGitRepository() {}
+    protected HttpGitRepository() {}
 
     /**
      * Opens the repository this UI-bound object holds on to.
@@ -47,6 +49,7 @@ public abstract class HttpGitRepository {
     /**
      * Returns the {@link ReceivePack} that handles "git push" from client.
      *
+     * <p>
      * The most basic implementation is the following, which allows anyone to push to this repository,
      * so normally you want some kind of access check before that. {@link DefaultReceivePackFactory} isn't suitable
      * here because it requires that the user has non-empty name, which isn't necessarily true in Jenkins
@@ -58,12 +61,39 @@ public abstract class HttpGitRepository {
      *
      * @see ReceivePackFactory#create(Object, Repository)
      */
-    public abstract ReceivePack createReceivePack(HttpServletRequest context, Repository db)
-            throws ServiceNotEnabledException, ServiceNotAuthorizedException;
+    @SuppressWarnings({"deprecated", "java:S1874"})
+    public ReceivePack createReceivePack(HttpServletRequest context, Repository db)
+            throws ServiceNotEnabledException, ServiceNotAuthorizedException {
+        if (Util.isOverridden(
+                HttpGitRepository.class,
+                getClass(),
+                "createReceivePack",
+                javax.servlet.http.HttpServletRequest.class,
+                Repository.class)) {
+            return createReceivePack(HttpServletRequestWrapper.fromJakartaHttpServletRequest(context), db);
+        }
+        throw new AbstractMethodError("Implementing class '" + this.getClass().getName() + "' does not override "
+                + "either overload of the createReceivePack method.");
+    }
+
+    /**
+     * @deprecated Override {@link #createReceivePack(HttpServletRequest, Repository)} instead.
+     */
+    @Deprecated(since = "134")
+    public ReceivePack createReceivePack(javax.servlet.http.HttpServletRequest context, Repository db)
+            throws ServiceNotEnabledException, ServiceNotAuthorizedException {
+        if (Util.isOverridden(
+                HttpGitRepository.class, getClass(), "createReceivePack", HttpServletRequest.class, Repository.class)) {
+            return createReceivePack(HttpServletRequestWrapper.toJakartaHttpServletRequest(context), db);
+        }
+        throw new AbstractMethodError("Implementing class '" + this.getClass().getName() + "' does not override "
+                + "either overload of the createReceivePack method.");
+    }
 
     /**
      * Returns the {@link UploadPack} that handles "git fetch" from client.
      *
+     * <p>
      * The most basic implementation is the following, which exposes this repository to everyone.
      *
      * <pre>
@@ -72,42 +102,56 @@ public abstract class HttpGitRepository {
      *
      * @see UploadPackFactory#create(Object, Repository)
      */
-    public abstract UploadPack createUploadPack(HttpServletRequest context, Repository db)
-            throws ServiceNotEnabledException, ServiceNotAuthorizedException;
+    @SuppressWarnings({"deprecated", "java:S1874"})
+    public UploadPack createUploadPack(HttpServletRequest context, Repository db)
+            throws ServiceNotEnabledException, ServiceNotAuthorizedException {
+        if (Util.isOverridden(
+                HttpGitRepository.class,
+                getClass(),
+                "createUploadPack",
+                javax.servlet.http.HttpServletRequest.class,
+                Repository.class)) {
+            return createUploadPack(HttpServletRequestWrapper.fromJakartaHttpServletRequest(context), db);
+        }
+        throw new AbstractMethodError("Implementing class '" + this.getClass().getName() + "' does not override "
+                + "either overload of the createUploadPack method.");
+    }
+
+    /**
+     * @deprecated Override {@link #createUploadPack(HttpServletRequest, Repository)} instead.
+     */
+    @Deprecated(since = "134")
+    public UploadPack createUploadPack(javax.servlet.http.HttpServletRequest context, Repository db)
+            throws ServiceNotEnabledException, ServiceNotAuthorizedException {
+        if (Util.isOverridden(
+                HttpGitRepository.class, getClass(), "createUploadPack", HttpServletRequest.class, Repository.class)) {
+            return createUploadPack(HttpServletRequestWrapper.toJakartaHttpServletRequest(context), db);
+        }
+        throw new AbstractMethodError("Implementing class '" + this.getClass().getName() + "' does not override "
+                + "either overload of the createUploadPack method.");
+    }
 
     /**
      * to make sure the user has the permission to pull.
      */
     public void checkPullPermission() {
-        Jenkins.getInstance().checkPermission(Jenkins.READ);
+        Jenkins.get().checkPermission(Jenkins.READ);
     }
 
     protected GitServlet init() {
         GitServlet g = new GitServlet();
-        g.setRepositoryResolver(new org.eclipse.jgit.transport.resolver.RepositoryResolver<HttpServletRequest>() {
-            public Repository open(HttpServletRequest req, String name) throws RepositoryNotFoundException {
-                try {
-                    return openRepository();
-                } catch (IOException e) {
-                    throw new RepositoryNotFoundException(req.getRequestURI(), e);
-                }
+        g.setRepositoryResolver((req, name) -> {
+            try {
+                return openRepository();
+            } catch (IOException e) {
+                throw new RepositoryNotFoundException(req.getRequestURI(), e);
             }
         });
 
         // this creates (and thus configures) the receiver program
-        g.setReceivePackFactory(new ReceivePackFactory<HttpServletRequest>() {
-            public ReceivePack create(HttpServletRequest req, Repository db)
-                    throws ServiceNotEnabledException, ServiceNotAuthorizedException {
-                return createReceivePack(req, db);
-            }
-        });
+        g.setReceivePackFactory(this::createReceivePack);
 
-        g.setUploadPackFactory(new UploadPackFactory<HttpServletRequest>() {
-            public UploadPack create(HttpServletRequest req, Repository db)
-                    throws ServiceNotEnabledException, ServiceNotAuthorizedException {
-                return createUploadPack(req, db);
-            }
-        });
+        g.setUploadPackFactory(this::createUploadPack);
 
         try {
             g.init(new ServletConfig() {
@@ -116,23 +160,19 @@ public abstract class HttpGitRepository {
                 }
 
                 public ServletContext getServletContext() throws IllegalStateException {
-                    Jenkins j = Jenkins.getInstance();
-                    if (j == null) {
-                        throw new IllegalStateException();
-                    }
-                    return j.servletContext;
+                    return Jenkins.get().getServletContext();
                 }
 
                 public String getInitParameter(String name) {
                     return null;
                 }
 
-                public Enumeration getInitParameterNames() {
-                    return new Vector().elements();
+                public Enumeration<String> getInitParameterNames() {
+                    return Collections.emptyEnumeration();
                 }
             });
         } catch (ServletException e) {
-            LOGGER.log(Level.WARNING, "Failed to initialize GitServlet for " + this, e);
+            LOGGER.log(Level.WARNING, e, () -> "Failed to initialize GitServlet for " + this);
             causeOfDeath = e;
         }
         return g;
@@ -141,7 +181,7 @@ public abstract class HttpGitRepository {
     /**
      * Handles git smart HTTP protocol.
      */
-    public void doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+    public void doDynamic(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
         if (g == null) g = init();
 
         if (causeOfDeath != null) throw new ServletException(causeOfDeath);

--- a/src/main/java/org/jenkinsci/plugins/gitserver/RepositoryResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/RepositoryResolver.java
@@ -2,12 +2,11 @@ package org.jenkinsci.plugins.gitserver;
 
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import java.io.IOException;
 import jenkins.model.Jenkins;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.ReceivePack;
 import org.eclipse.jgit.transport.UploadPack;
-
-import java.io.IOException;
 
 /**
  * Resolves the full name of the repository as given by Git clients to actual {@link Repository}.

--- a/src/main/java/org/jenkinsci/plugins/gitserver/RepositoryResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/RepositoryResolver.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.gitserver;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import java.io.IOException;
@@ -47,6 +48,7 @@ public abstract class RepositoryResolver implements ExtensionPoint {
      *      null if this resolver doesn't recognize the given path name.
      *      This will allow other {@link RepositoryResolver}s to get a shot at the repository.
      */
+    @CheckForNull
     public abstract ReceivePack createReceivePack(String fullRepositoryName) throws IOException, InterruptedException;
 
     /**
@@ -60,13 +62,10 @@ public abstract class RepositoryResolver implements ExtensionPoint {
      *      null if this resolver doesn't recognize the given path name.
      *      This will allow other {@link RepositoryResolver}s to get a shot at the repository.
      */
+    @CheckForNull
     public abstract UploadPack createUploadPack(String fullRepositoryName) throws IOException, InterruptedException;
 
     public static ExtensionList<RepositoryResolver> all() throws IllegalStateException {
-        Jenkins j = Jenkins.getInstance();
-        if (j == null) {
-            throw new IllegalStateException();
-        }
-        return j.getExtensionList(RepositoryResolver.class);
+        return Jenkins.get().getExtensionList(RepositoryResolver.class);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/gitserver/ssh/AbstractGitCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/ssh/AbstractGitCommand.java
@@ -15,7 +15,7 @@ import org.kohsuke.args4j.ParserProperties;
  * @author Kohsuke Kawaguchi
  */
 abstract class AbstractGitCommand extends AsynchronousCommand {
-    @Argument(index=0, metaVar="REPO", required=true, usage="repository name")
+    @Argument(index = 0, metaVar = "REPO", required = true, usage = "repository name")
     protected String repoName;
 
     AbstractGitCommand(CommandLine cmdLine) {
@@ -24,15 +24,16 @@ abstract class AbstractGitCommand extends AsynchronousCommand {
 
     @Override
     protected final int runCommand() throws Exception {
-            try {
-                ParserProperties properties = ParserProperties.defaults().withAtSyntax(false);
-                new CmdLineParser(this, properties).parseArgument(getCmdLine().subList(1,getCmdLine().size()));
-            } catch (CmdLineException e) {
-                throw new AbortException(e.getMessage());
-            }
+        try {
+            ParserProperties properties = ParserProperties.defaults().withAtSyntax(false);
+            new CmdLineParser(this, properties)
+                    .parseArgument(getCmdLine().subList(1, getCmdLine().size()));
+        } catch (CmdLineException e) {
+            throw new AbortException(e.getMessage());
+        }
 
-            return doRun();
+        return doRun();
     }
-    
+
     protected abstract int doRun() throws Exception;
 }

--- a/src/main/java/org/jenkinsci/plugins/gitserver/ssh/ReceivePackCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/ssh/ReceivePackCommand.java
@@ -19,13 +19,12 @@ public class ReceivePackCommand extends AbstractGitCommand {
     protected int doRun() throws Exception {
         for (RepositoryResolver rr : RepositoryResolver.all()) {
             ReceivePack rp = rr.createReceivePack(repoName);
-            if (rp!=null) {
-                rp.receive(getInputStream(),getOutputStream(),getErrorStream());
+            if (rp != null) {
+                rp.receive(getInputStream(), getOutputStream(), getErrorStream());
                 return 0;
             }
         }
 
-        throw new AbortException("No such repository exists:"+repoName);
-
+        throw new AbortException("No such repository exists:" + repoName);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/gitserver/ssh/ReceivePackCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/ssh/ReceivePackCommand.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.gitserver.ssh;
 
 import hudson.AbortException;
+import java.io.IOException;
 import org.eclipse.jgit.transport.ReceivePack;
 import org.jenkinsci.main.modules.sshd.SshCommandFactory.CommandLine;
 import org.jenkinsci.plugins.gitserver.RepositoryResolver;
@@ -16,7 +17,7 @@ public class ReceivePackCommand extends AbstractGitCommand {
     }
 
     @Override
-    protected int doRun() throws Exception {
+    protected int doRun() throws IOException, InterruptedException {
         for (RepositoryResolver rr : RepositoryResolver.all()) {
             ReceivePack rp = rr.createReceivePack(repoName);
             if (rp != null) {

--- a/src/main/java/org/jenkinsci/plugins/gitserver/ssh/SshCommandFactoryImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/ssh/SshCommandFactoryImpl.java
@@ -11,12 +11,10 @@ import org.jenkinsci.main.modules.sshd.SshCommandFactory;
 public class SshCommandFactoryImpl extends SshCommandFactory {
     @Override
     public Command create(CommandLine cmds) {
-        if (cmds.size()<1)  return null;
+        if (cmds.size() < 1) return null;
 
-        if (cmds.get(0).equals("git-receive-pack"))
-            return new ReceivePackCommand(cmds);
-        if (cmds.get(0).equals("git-upload-pack"))
-            return new UploadPackCommand(cmds);
+        if (cmds.get(0).equals("git-receive-pack")) return new ReceivePackCommand(cmds);
+        if (cmds.get(0).equals("git-upload-pack")) return new UploadPackCommand(cmds);
 
         return null;
     }

--- a/src/main/java/org/jenkinsci/plugins/gitserver/ssh/SshCommandFactoryImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/ssh/SshCommandFactoryImpl.java
@@ -11,7 +11,7 @@ import org.jenkinsci.main.modules.sshd.SshCommandFactory;
 public class SshCommandFactoryImpl extends SshCommandFactory {
     @Override
     public Command create(CommandLine cmds) {
-        if (cmds.size() < 1) return null;
+        if (cmds.isEmpty()) return null;
 
         if (cmds.get(0).equals("git-receive-pack")) return new ReceivePackCommand(cmds);
         if (cmds.get(0).equals("git-upload-pack")) return new UploadPackCommand(cmds);

--- a/src/main/java/org/jenkinsci/plugins/gitserver/ssh/UploadPackCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/ssh/UploadPackCommand.java
@@ -20,12 +20,12 @@ public class UploadPackCommand extends AbstractGitCommand {
     protected int doRun() throws Exception {
         for (RepositoryResolver rr : RepositoryResolver.all()) {
             UploadPack up = rr.createUploadPack(repoName);
-            if (up!=null) {
-                up.upload(getInputStream(),getOutputStream(),getErrorStream());
+            if (up != null) {
+                up.upload(getInputStream(), getOutputStream(), getErrorStream());
                 return 0;
             }
         }
 
-        throw new AbortException("No such repository exists:"+repoName);
+        throw new AbortException("No such repository exists:" + repoName);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/gitserver/ssh/UploadPackCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitserver/ssh/UploadPackCommand.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.gitserver.ssh;
 
 import hudson.AbortException;
+import java.io.IOException;
 import org.eclipse.jgit.transport.UploadPack;
 import org.jenkinsci.main.modules.sshd.SshCommandFactory.CommandLine;
 import org.jenkinsci.plugins.gitserver.RepositoryResolver;
@@ -17,11 +18,13 @@ public class UploadPackCommand extends AbstractGitCommand {
     }
 
     @Override
-    protected int doRun() throws Exception {
+    protected int doRun() throws IOException, InterruptedException {
         for (RepositoryResolver rr : RepositoryResolver.all()) {
             UploadPack up = rr.createUploadPack(repoName);
             if (up != null) {
-                up.upload(getInputStream(), getOutputStream(), getErrorStream());
+                try (up) {
+                    up.upload(getInputStream(), getOutputStream(), getErrorStream());
+                }
                 return 0;
             }
         }

--- a/src/test/java/org/jenkinsci/plugins/gitserver/ssh/ReceivePackCommandTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitserver/ssh/ReceivePackCommandTest.java
@@ -1,10 +1,22 @@
 package org.jenkinsci.plugins.gitserver.ssh;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
 import hudson.Functions;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.util.EnumSet;
+import java.util.concurrent.TimeUnit;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.channel.ClientChannel;
 import org.apache.sshd.client.channel.ClientChannelEvent;
@@ -19,19 +31,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
 
 /**
  * This class contains code borrowed and adapted from the Jenkins SSHD plugin.

--- a/src/test/java/org/jenkinsci/plugins/gitserver/ssh/ReceivePackCommandTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitserver/ssh/ReceivePackCommandTest.java
@@ -1,12 +1,9 @@
 package org.jenkinsci.plugins.gitserver.ssh;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import hudson.Functions;
+import hudson.model.User;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -26,30 +23,23 @@ import org.apache.sshd.client.session.ClientSession;
 import org.jenkinsci.main.modules.cli.auth.ssh.PublicKeySignatureWriter;
 import org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl;
 import org.jenkinsci.main.modules.sshd.SSHD;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * This class contains code borrowed and adapted from the Jenkins SSHD plugin.
  * Original source: org.jenkinsci.main.modules.sshd.SSHDTest.java
  */
-public class ReceivePackCommandTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
-    @Before
-    public void setUp() {
-        assumeFalse(Functions.isWindows());
-    }
+@WithJenkins
+class ReceivePackCommandTest {
+    private static final String USER = "enabled";
 
     @Test
     @Issue("SECURITY-3319")
-    public void shouldNotParseAtChar() throws Exception {
-        hudson.model.User enabled = hudson.model.User.getOrCreateByIdOrFullName("enabled");
+    void shouldNotParseAtChar(JenkinsRule ignored) throws Exception {
+        User enabled = User.getOrCreateByIdOrFullName(USER);
         KeyPair keyPair = generateKeys(enabled);
         SSHD server = SSHD.get();
         server.setPort(0);
@@ -63,7 +53,7 @@ public class ReceivePackCommandTest {
         try (SshClient client = SshClient.setUpDefaultClient()) {
             client.setServerKeyVerifier(AcceptAllServerKeyVerifier.INSTANCE);
             client.start();
-            ConnectFuture future = client.connect("enabled", new InetSocketAddress(server.getActualPort()));
+            ConnectFuture future = client.connect(USER, new InetSocketAddress("localhost", server.getActualPort()));
             try (ClientSession session = future.verify(10, TimeUnit.SECONDS).getSession()) {
                 session.addPublicKeyIdentity(keyPair);
                 assertTrue(session.auth().await(10, TimeUnit.SECONDS));
@@ -76,14 +66,14 @@ public class ReceivePackCommandTest {
                     channel.waitFor(EnumSet.of(ClientChannelEvent.CLOSED), TimeUnit.SECONDS.toMillis(5));
 
                     String errorMessage = errorStream.toString();
-                    assertThat(errorMessage, containsString("@" + tempPath));
-                    assertThat(errorMessage, not(containsString(content)));
+                    assertTrue(errorMessage.contains("@" + tempPath));
+                    assertFalse(errorMessage.contains(content));
                 }
             }
         }
     }
 
-    private static KeyPair generateKeys(hudson.model.User user) throws NoSuchAlgorithmException, IOException {
+    private static KeyPair generateKeys(User user) throws NoSuchAlgorithmException, IOException {
         // I'd prefer to generate Ed25519 keys here, but the API is too awkward currently
         // ECDSA keys would be even more awkward as we'd need a copy of the curve parameters
         KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");

--- a/src/test/java/org/jenkinsci/plugins/gitserver/ssh/Security3342Test.java
+++ b/src/test/java/org/jenkinsci/plugins/gitserver/ssh/Security3342Test.java
@@ -1,22 +1,27 @@
 package org.jenkinsci.plugins.gitserver.ssh;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import hudson.Functions;
+import hudson.model.User;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-import java.util.Collections;
 import java.util.List;
 import jenkins.model.Jenkins;
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.InvalidRemoteException;
+import org.eclipse.jgit.errors.NoRemoteRepositoryException;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.SshSessionFactory;
 import org.eclipse.jgit.transport.sshd.ServerKeyDatabase;
@@ -24,41 +29,31 @@ import org.eclipse.jgit.transport.sshd.SshdSessionFactory;
 import org.jenkinsci.main.modules.cli.auth.ssh.PublicKeySignatureWriter;
 import org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl;
 import org.jenkinsci.main.modules.sshd.SSHD;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class Security3342Test {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
-    @Rule
-    public TemporaryFolder tmp = new TemporaryFolder();
-
-    @Before
-    public void setUp() {
-        assumeFalse(Functions.isWindows());
-    }
+@WithJenkins
+class Security3342Test {
+    private static final String USER = "tester";
 
     @Test
     @Issue("SECURITY-3342")
-    public void openRepositoryPermissionCheckTest() throws Exception {
+    void openRepositoryPermissionCheckTest(@TempDir Path tmp, JenkinsRule j) throws Exception {
 
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(
-                new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().to("tester"));
-        hudson.model.User tester = hudson.model.User.getOrCreateByIdOrFullName("tester");
+                new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().to(USER));
+        User tester = User.getOrCreateByIdOrFullName(USER);
         KeyPair keyPair = generateKeys(tester);
         j.jenkins.save();
 
         // Fixed ssh port for Jenkins ssh server
         SSHD server = SSHD.get();
-        server.setPort(2222);
+        server.setPort(0);
 
         final SshdSessionFactory instance = new SshdSessionFactory() {
             @Override
@@ -72,7 +67,7 @@ public class Security3342Test {
                     @Override
                     public List<PublicKey> lookup(
                             String connectAddress, InetSocketAddress remoteAddress, Configuration config) {
-                        return Collections.emptyList();
+                        return List.of();
                     }
 
                     @Override
@@ -90,39 +85,35 @@ public class Security3342Test {
         SshSessionFactory.setInstance(instance);
 
         CloneCommand clone = Git.cloneRepository();
-        clone.setURI("ssh://tester@localhost:2222/userContent.git");
-        File dir1 = tmp.newFolder();
-        clone.setDirectory(dir1);
+        clone.setURI("ssh://" + USER + "@localhost:" + server.getActualPort() + "/userContent.git");
+        Path dir1 = Files.createTempDirectory(tmp, null);
+        clone.setDirectory(dir1.toFile());
 
         // Do the git clone for a user with Jenkins.READ permission
-        Git gitClone1 = clone.call();
-        File gitDir1 = new File(dir1, ".git");
-        assertTrue(".git directory exist, clone operation succeed", gitDir1.exists());
+        assertDoesNotThrow(clone::call).close();
+        Path gitDir1 = dir1.resolve(".git");
+        assertTrue(Files.isDirectory(gitDir1), ".git directory exist, clone operation succeed");
 
         // Do the git clone for a user without Jenkins.READ permission
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy());
         j.jenkins.save();
 
-        File dir2 = tmp.newFolder();
-        clone.setDirectory(dir2);
+        Path dir2 = Files.createTempDirectory(tmp, null);
+        clone.setDirectory(dir2.toFile());
 
-        try {
-            Git gitClone2 = clone.call();
-        } catch (Exception e) {
-            // Verify that the expected exception was caught with the correct message
-            assertTrue(
-                    e.getCause() != null
-                            && e.getCause()
-                                    .getMessage()
-                                    .contains(
-                                            "hudson.security.AccessDeniedException3: tester is missing the Overall/Read permission"));
-        }
+        // Verify that the expected exception was caught with the correct message
+        InvalidRemoteException e = assertThrows(InvalidRemoteException.class, clone::call);
+        assertInstanceOf(NoRemoteRepositoryException.class, e.getCause());
+        NoRemoteRepositoryException e2 = (NoRemoteRepositoryException) e.getCause();
+        assertTrue(e2.getMessage()
+                .contains("hudson.security.AccessDeniedException3: tester is missing the Overall/Read permission"));
+
         // Verify that the .git directory is not created
-        File gitDir2 = new File(dir2, ".git");
-        assertFalse(".git directory exist, clone operation succeed", gitDir2.exists());
+        Path gitDir2 = dir2.resolve(".git");
+        assertFalse(Files.isDirectory(gitDir2), ".git directory exist, clone operation succeed");
     }
 
-    private static KeyPair generateKeys(hudson.model.User user) throws NoSuchAlgorithmException, IOException {
+    private static KeyPair generateKeys(User user) throws NoSuchAlgorithmException, IOException {
         // I'd prefer to generate Ed25519 keys here, but the API is too awkward currently
         // ECDSA keys would be even more awkward as we'd need a copy of the curve parameters
         KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");


### PR DESCRIPTION
* Adapter methods are added for old overrides.
* Switch to JUnit 5 for tests

Required for the Scriptler plugin to modernize as well without breaking SSH compatibility.

### Testing done

Unit tests updated and run.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
